### PR TITLE
forgotten motor toolbox branch change

### DIFF
--- a/orbita3d_c_api/Cargo.toml
+++ b/orbita3d_c_api/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 libc = "0.2.147"
 
 # Can we "inherit" the version from the workspace?
-motor_toolbox_rs = { git = "https://github.com/pollen-robotics/motor_toolbox_rs", branch="24-add-get_board_state" }
-# motor_toolbox_rs = { git = "https://github.com/pollen-robotics/motor_toolbox_rs", branch="support-poulpe" }
+# motor_toolbox_rs = { git = "https://github.com/pollen-robotics/motor_toolbox_rs", branch="24-add-get_board_state" }
+motor_toolbox_rs = { git = "https://github.com/pollen-robotics/motor_toolbox_rs", branch="support-poulpe" }
 once_cell = "1.18.0"
 orbita3d_controller = { version = "0.1.0", path = "../orbita3d_controller" }
 orbita3d_kinematics = { version = "0.1.0", path = "../orbita3d_kinematics" }

--- a/orbita3d_controller/Cargo.toml
+++ b/orbita3d_controller/Cargo.toml
@@ -9,8 +9,7 @@ edition = "2021"
 cache_cache = "0.1.1"
 log = "0.4.20"
 env_logger = "0.8.4"
-# motor_toolbox_rs = { git = "https://github.com/pollen-robotics/motor_toolbox_rs", branch="support-poulpe" }
-motor_toolbox_rs = { git = "https://github.com/pollen-robotics/motor_toolbox_rs", branch="24-add-get_board_state" }
+motor_toolbox_rs = { git = "https://github.com/pollen-robotics/motor_toolbox_rs", branch="support-poulpe" }
 orbita3d_kinematics = { version = "0.1.0", path = "../orbita3d_kinematics" }
 rustypot = { git = "https://github.com/pollen-robotics/rustypot", branch="support-poulpe" }
 serde = { version = "1.0.183", features = ["derive"] }


### PR DESCRIPTION
A small one, branch change from `24-get-goard-state` to `support-poulpe` as it has been merged. 