### PR TITLE
Update angle limits of O3D.

### DIFF
--- a/orbita3d_description/urdf/orbita3d.urdf.xacro
+++ b/orbita3d_description/urdf/orbita3d.urdf.xacro
@@ -152,7 +152,7 @@
 
       <child link="${name}_dummy_link1"/>
       <axis xyz="1 0 0"/>
-      <limit lower="-0.35" upper="0.35" effort="1000.0" velocity="100.0"/>
+      <limit lower="-0.70" upper="0.70" effort="1000.0" velocity="100.0"/>
       <dynamics damping="${damping}" friction="${friction}"/>
     </joint>
 
@@ -161,7 +161,7 @@
       <parent link="${name}_dummy_link1"/>
       <child link="${name}_dummy_link2"/>
       <axis xyz="0 1 0"/>
-      <limit lower="-0.35" upper="0.35" effort="1000.0" velocity="100.0"/>
+      <limit lower="-0.70" upper="0.70" effort="1000.0" velocity="100.0"/>
       <dynamics damping="${damping}" friction="${friction}"/>
     </joint>
 


### PR DESCRIPTION
Update angle limits of O3D on the URDF, because it was limited to 20° in Mujoco. 
To be tested with [branch 7 of reachy2_mujoco_assets](https://github.com/pollen-robotics/reachy2_mujoco_assets/pull/8) : 

**To test it :** 
```
from reachy2_sdk import ReachySDK
reachy = ReachySDK('localhost')
reachy.head.goto([20,0,0])
reachy.head.goto([40,0,0])
reachy.l_arm.wrist.roll.goto(20)
reachy.l_arm.wrist.roll.goto(40)
```
Before the modification, the head and the wrist don't move between the two gotos, unlike after the change. 
